### PR TITLE
Update client.lua - prevent event spam

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -14,6 +14,7 @@ Citizen.CreateThread(function()
 					time = time - 1
 				else
 					TriggerServerEvent("AL13N-AFK:afk")
+					break
 				end
 			else
 				time = Config.timeAFK


### PR DESCRIPTION
This is necessary to prevent event spam for those who are in licenseID table.